### PR TITLE
fix: body for testcase failure tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ class TestCase {
         return this.passed ?
             `${ident(tab)}<testcase name="${this.name}" classname="${this.className}" />` :
             `${ident(tab)}<testcase name="${this.name}" classname="${this.className}" >\n` +
-            `${ident(tab + 1)}<failure message="${this.failMessage}" />\n` +
+            `${ident(tab + 1)}<failure message="${this.failMessage}">${this.failMessage}</failure>\n` +
             `${ident(tab)}</testcase>`;
     }
 }


### PR DESCRIPTION
Hello

Due to junit xml format, failure tag can have a body with stacktrace. Using empty tag without a body may cause some softwares that are expecting the body to fail. E.g.https://github.com/marketplace/actions/test-reporter