### PR TITLE
feat: possibility to exclude thresholds from suites

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ class TestSuite {
 }
 
 class Report {
-    constructor(data) {
+    constructor(data, includeThresholds) {
         this.nextSuiteId = 0;
         this.suites = [];
 
@@ -117,7 +117,9 @@ class Report {
             }
         }
 
-        this.parseMetrics(data);
+        if (includeThresholds) {
+            this.parseMetrics(data);
+        }
     }
 
     parseMetrics(data) {
@@ -195,8 +197,8 @@ class Report {
     }
 }
 
-function jUnit(data) {
-    return new Report(data).toXml();
+function jUnit(data, includeThresholds = true) {
+    return new Report(data, includeThresholds).toXml();
 }
 
 exports.jUnit = jUnit;


### PR DESCRIPTION
Hello

We are using k6 as oure testing framework, not performance testing. We use chai assertion only to fail the tests. I.e. we do not use thresholds at all.
So we are not interested to see thresholds reported as a separate test suite.

The PR adds a flag that allows to exclude thresholds from reulting report.