### PR TITLE
fix: testcase failure detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ class TestCase {
         this.name = sanitizeName(get(check, ["name"]));
         const passed = get(check, ["passes"]);
         const failed = get(check, ["fails"])
-        this.passed = passed > 0 && failed === 0;
+        this.passed = passed > 0 && failed <= passed;
 
         if (!this.passed) {
             const passPercent = passed / (passed + failed) * 100;


### PR DESCRIPTION
Hello

We are using chai assertions with custom retryn function.
So we are expecting that a test may fail few times during retry and then eventually pass.
Although k6 reports this as a failure - it is not a failure.

The PR tries to improve testcase faulure detection by comparing number of passes vs number of failures.